### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,3 @@ notifications:
     secure: aPSxTv5df576zSV9Sn+yLrp76EdK3yqSfvtTCWkaj3XNJPGpgUPMGC3XYKubPYnyjcbP7YAkXk2ui+aR9ipoN4Vb3r8rWa714lRK2mm3fbL+vqh8t9RZZK0Eqc77jvcmyvaJPEq8hAzJvavK4xDv+wL3sSqBFvqfBjsZfAw2G+1B4AGzlLVxmQh6VanFLCbi4s/7LvEE4CjrIKpt42cYRU46HOrxLmYBn6mYrvVv/zLlCM6i/7DOcuMz6weYZpjbsL/KRx65q3BM/GKnzzQB7oRfP4UXgsnJ1+xMTy1mlb7Tqf4TZQ15Mk/AL3zil7UxLbcAW6xG0OZ+yPtnayb8tgpdTJ3Yxa+EdD67h7bQH9F7y4bkeiHkBHJIx+4farFwq2eOcnN1Fu3P2nQwpEhWhaiFak2KpZUkm4J5qLGu1JU056go/hARlm4fEHq/mTVGjwgSMk1injpywuxkWtNH6wcBEluW66jcpPN0Dvc2u9hw1NUt9W5ZD4U/c21PMxPf/KsJ7EDBiQCibJNE9pHp9gfWi31o4pEj7niSNKlTFefQr+QXwbrCwvG/F2QvDT2PrxyFKsZo55yDk4OWZb+aCOVLPaAhpphmiUqqkKDtRNkxfAT+Y8Sh0+yvCx3mGx7idFADiWcAdq9QkRFBke4XnIHfcOYENxt+VMGPqEXy5gU=
   email:
   - PhoneGapCI@adobe.com
-branches:
-  only:
-  - gh-pages
-  - /\S*/


### PR DESCRIPTION
`gh-pages` is ignored by default by [travis-ci](https://docs.travis-ci.com/user/customizing-the-build#Building-Specific-Branches), but now that `master` is building I removed the safelist from the travis config file.